### PR TITLE
Automatically set the PWD variable in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 MAKEFLAGS+=--warn-undefined-variables
-export PWD =/home/user/Desktop/FPGA_IGNITE_2024/
+export PWD =$(shell pwd)
 export CARAVEL_ROOT?=$(PWD)/caravel
 export UPRJ_ROOT?=$(PWD)
 PRECHECK_ROOT?=${HOME}/mpw_precheck


### PR DESCRIPTION
By using `$(shell pwd)` the current working directory can be obtained inside the Makefile and assigned to the PWD variable.